### PR TITLE
Fix Docker runtime for Jetson

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,32 @@ cd jetson-rag-pipeline
 
 2. Place your PDF documents in the `docs` folder.
 
-3. Start the services using Docker Compose:
+3. Start the services using Docker Compose. On Jetson devices the services
+   require the `nvidia` container runtime, which is already configured in
+   `docker-compose.yml`:
 ```bash
 docker compose up -d
+```
+
+### NVIDIA runtime setup (Jetson)
+If you see an "unknown or invalid runtime name: nvidia" error, the NVIDIA
+container runtime may not be registered with Docker. Create or update
+`/etc/docker/daemon.json` as follows and then restart Docker:
+
+```json
+{
+  "default-runtime": "nvidia",
+  "runtimes": {
+    "nvidia": {
+      "path": "nvidia-container-runtime",
+      "runtimeArgs": []
+    }
+  }
+}
+```
+
+```bash
+sudo systemctl restart docker
 ```
 
 4. Pull the LLM model (first time only):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3.8'
-
 services:
   frontend:
-    build: 
+    build:
       context: ./frontend
       dockerfile: Dockerfile
     ports:
@@ -14,6 +12,7 @@ services:
 
   rag-api:
     build: .
+    runtime: nvidia
     ports:
       - "8000:8000"
     volumes:
@@ -24,27 +23,14 @@ services:
       - MODEL_NAME=llama3.2:3b
     depends_on:
       - ollama
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
   ollama:
     image: ollama/ollama:latest
+    runtime: nvidia
     ports:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 volumes:
-  ollama_data: 
+  ollama_data:


### PR DESCRIPTION
## Summary
- ensure Jetson services use the `nvidia` runtime
- mention `nvidia` runtime requirement in the README
- document how to add the runtime to `/etc/docker/daemon.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68410dc1ab788322bdaacdb73c26c686