### PR TITLE
Update embedding to avoid torch, adjust dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ python-dotenv==1.0.0
 requests==2.31.0
 fastapi==0.109.1
 uvicorn==0.27.1
-pydantic==2.6.1 
+pydantic==2.6.1
+transformers==4.41.2
+fastembed==0.7.1

--- a/src/rag.py
+++ b/src/rag.py
@@ -1,9 +1,15 @@
-from llama_index import VectorStoreIndex, SimpleDirectoryReader, ServiceContext
+from llama_index import (
+    VectorStoreIndex,
+    SimpleDirectoryReader,
+    ServiceContext,
+    StorageContext,
+    load_index_from_storage,
+)
 from llama_index.llms import Ollama
-from llama_index.embeddings import HuggingFaceEmbeddings
+from llama_index.embeddings.fastembed import FastEmbedEmbedding
 import os
 from typing import List, Optional
-from . import config
+import config
 
 class ShopManualRAG:
     def __init__(self):
@@ -15,10 +21,8 @@ class ShopManualRAG:
             max_tokens=config.MAX_TOKENS,
         )
         
-        # Initialize embeddings
-        self.embed_model = HuggingFaceEmbeddings(
-            model_name="BAAI/bge-small-en-v1.5"
-        )
+        # Initialize embeddings using fastembed to avoid heavy torch dependency
+        self.embed_model = FastEmbedEmbedding(model_name="BAAI/bge-small-en-v1.5")
         
         # Create service context
         self.service_context = ServiceContext.from_defaults(


### PR DESCRIPTION
## Summary
- fix incorrect embedding import
- use `FastEmbedEmbedding` to remove PyTorch requirement
- add `transformers` and `fastembed` dependencies

## Testing
- `python3 src/index_docs.py` *(fails: Could not download model from HuggingFace due to proxy restrictions)*